### PR TITLE
fix: 環境変数参照を MICROCMS_MANAGEMENT_API_KEY から MICROCMS_API_KEY に更新

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ microcms-cli gen-types blog --all
 
 # CIなどで環境変数をインライン指定
 MICROCMS_SERVICE_DOMAIN=your-service-id \
-MICROCMS_MANAGEMENT_API_KEY=your-management-api-key \
+MICROCMS_API_KEY=your-management-api-key \
 microcms-cli gen-types blog
 ```
 
@@ -59,7 +59,7 @@ microcms-cli gen-types blog
 - `-o, --output <path>`: 出力先（ディレクトリ指定時は `<path>/microcms.d.ts`、デフォルト `./types/microcms.d.ts`）
 - `--all`: 全エンドポイントの型を生成
 - `--service-domain <domain>`: `MICROCMS_SERVICE_DOMAIN` をCLI引数で上書き
-- `--api-key <key>`: `MICROCMS_MANAGEMENT_API_KEY` をCLI引数で上書き
+- `--api-key <key>`: `MICROCMS_API_KEY` をCLI引数で上書き
 
 #### Required environment variables
 
@@ -69,12 +69,12 @@ CLI引数で指定しない場合、以下の環境変数が必要です。
 
 ```bash
 MICROCMS_SERVICE_DOMAIN=your-service-id
-MICROCMS_MANAGEMENT_API_KEY=your-management-api-key
+MICROCMS_API_KEY=your-management-api-key
 ```
 
 #### Required Management API permission
 
-`MICROCMS_MANAGEMENT_API_KEY` には、マネジメントAPIのGET権限として **「API情報の取得」** が必要です。
+`MICROCMS_API_KEY` には、マネジメントAPIのGET権限として **「API情報の取得」** が必要です。
 
 > 補足: 単一 endpoint で `apiType` が取得できない場合、CLI は警告を出して LIST として型生成します。
 

--- a/src/commands/gen-types/config.ts
+++ b/src/commands/gen-types/config.ts
@@ -32,11 +32,11 @@ export function resolveConfig(options: GenTypesOptions): ManagementClientConfig 
 
   const apiKey =
     toStringValue(options.apiKey) ??
-    toStringValue(process.env.MICROCMS_MANAGEMENT_API_KEY);
+    toStringValue(process.env.MICROCMS_API_KEY);
   if (!apiKey) {
     const envDir = process.env.__MICROCMS_CLI_ENV_DIR ?? process.cwd();
     throw new Error(
-      'MICROCMS_MANAGEMENT_API_KEY is required. You can also pass --api-key.\n' +
+      'MICROCMS_API_KEY is required. You can also pass --api-key.\n' +
         `(Searched for .env / .env.local in: ${envDir}. CWD: ${process.cwd()})`,
     );
   }

--- a/src/commands/gen-types/management-api.ts
+++ b/src/commands/gen-types/management-api.ts
@@ -32,7 +32,7 @@ async function fetchFromManagementApi(
     const responseBody = await response.text();
     if (response.status === 401) {
       throw new Error(
-        `Management API authentication failed (401). Check MICROCMS_MANAGEMENT_API_KEY. ${responseBody}`,
+        `Management API authentication failed (401). Check MICROCMS_API_KEY. ${responseBody}`,
       );
     }
     if (response.status === 403) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,7 +38,7 @@ program
   )
   .option('--all', 'Generate types for all endpoints')
   .option('--service-domain <domain>', 'Override MICROCMS_SERVICE_DOMAIN')
-  .option('--api-key <key>', 'Override MICROCMS_MANAGEMENT_API_KEY')
+  .option('--api-key <key>', 'Override MICROCMS_API_KEY')
   .action(async (endpointId: string | undefined, options: {
     output?: string;
     all?: boolean;


### PR DESCRIPTION
[API_KYEの重複について](https://github.com/wato787/microcms-cli/issues/7)の対応

-  `MICROCMS_MANAGEMENT_API_KE`を` MICROCMS_API_KEY`へリネーム