### PR TITLE
バージョン二重管理修正

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,12 @@
 #!/usr/bin/env node
 
 import fs from 'node:fs';
+import { createRequire } from 'node:module';
 import path from 'node:path';
 import dotenv from 'dotenv';
+
+const { version } = createRequire(import.meta.url)('../package.json') as { version: string };
+console.log('version:', version);
 
 function findEnvDir(dir: string): string | null {
   const parent = path.dirname(dir);
@@ -23,7 +27,7 @@ import { genTypesCommand } from './commands/generate/types/index.js';
 
 const program = new Command();
 
-program.name('microcms').description('CLI for microCMS').version('0.1.5');
+program.name('microcms').description('CLI for microCMS').version(version);
 
 program
   .command('generate:types [endpointId]')

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,6 @@ import path from 'node:path';
 import dotenv from 'dotenv';
 
 const { version } = createRequire(import.meta.url)('../package.json') as { version: string };
-console.log('version:', version);
 
 function findEnvDir(dir: string): string | null {
   const parent = path.dirname(dir);


### PR DESCRIPTION
## 概要

- Versionのハードコード管理修正

## 背景 / 目的

- バージョンが上がった際package.jsonが`"version": "0.1.4"`→`"version": "0.1.5"`となるがindex.tsも修正する手間やバージョンの不一致の可能性がある。

## 変更内容

- [x] package.json からバージョンを取得するよう修正

## 動作確認

- [x] `bun run build`
- [x]  `bun run dev --version`
- `"version": "0.1.6"`とし`console.log('version:', version);`を仕込み`bun run dev --version`を実行後バージョンが一致しているか
（2026/02/24段階 version": "0.1.5）
## 影響範囲

## 補足

